### PR TITLE
Change from std RwLock to tokio RwLock

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# 0.4.0
+  - changed the keyset (in the KeyStore struct) to use tokio::sync::RwLock (instead of std::sync::RwLock). The tokio::sync::RwLock "is fair (or write-preferring), in order to ensure that readers cannot starve writers". This also removes the possibility of deadlocks due to panics (albeit unlikely regardless). As a result, several functions in keystore.rs have now become async. 
+
 ## 0.3.0
 - use native Rust for cryptography ([ring](https://github.com/briansmith/ring) crate)
 - dropped support for ES512 and Ed448 signatures (**backwards incompatible change**)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bbjwt"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"
@@ -25,6 +25,7 @@ p384 = "0.13.0"
 p256 = "0.13.2"
 pkcs1 = { version = "0.7.5", features = ["std"] }
 der = { version = "0.7.8", features = ["alloc"] }
+tokio = { version = "1.35", features = ["sync"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ async fn main() {
     ... abbreviated ...,
   }"#;
   // Add the key
-  keystore.add_key(json_key);
+  keystore.add_key(json_key).await;
 
   let pem_key = r#"-----BEGIN PUBLIC KEY-----
 ..."#;
@@ -128,7 +128,7 @@ async fn main() {
     pem_key,
     Some("key-rsa"),
     KeyAlgorithm::RS256
-  ).unwrap();
+  ).await.unwrap();
 
   // Load a EC key from a PEM buffer
   keystore.add_ec_pem_key(
@@ -136,7 +136,7 @@ async fn main() {
     Some("key-ec"),
     EcCurve::P256,
     KeyAlgorithm::ES256
-  ).unwrap();
+  ).await.unwrap();
 
   // Load EdDSA key from a PEM buffer
   keystore.add_ec_pem_key(
@@ -144,7 +144,7 @@ async fn main() {
     Some("key-ed"),
     EcCurve::Ed25519,
     KeyAlgorithm::EdDSA
-  ).unwrap();
+  ).await.unwrap();
 
   // You can add more keys; in this case, the keys should have an ID and the JWT to be
   // validated should have a "kid" claim. Otherwise, bbjwt uses the first key in the set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ pub async fn validate_jwt(
   }
 
   /* get public key for signature validation */
-  let pubkey = keystore.key_by_id(kid_hdr.kid.as_deref())?;
+  let pubkey = keystore.key_by_id(kid_hdr.kid.as_deref()).await?;
 
   /* First, we verify the signature. */
   check_jwt_signature(&parts, &pubkey)?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -70,8 +70,9 @@ async fn validate_jwt_with_keystores(
 async fn unsupported_alg_jwt() {
   let ks = KeyStore::new().await.unwrap();
   ks.add_rsa_pem_key(&load_asset("rsa.pub.key"), Some("key-1"), KeyAlgorithm::RS256)
+    .await
     .expect("Failed to add RSA key");
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* verify valid token */
   let jwt = load_asset("id_token_unsupported_alg.txt");
@@ -85,11 +86,13 @@ async fn rsa256_valid_jwt() {
   let ks_good = KeyStore::new().await.unwrap();
   ks_good
     .add_rsa_pem_key(&load_asset("rsa.pub.key"), Some("key-1"), KeyAlgorithm::RS256)
+    .await
     .expect("Failed to add RSA384 key");
 
   let ks_bad = KeyStore::new().await.unwrap();
   ks_bad
     .add_rsa_pem_key(&load_asset("rsa.wrong.pub.key"), Some("key-1"), KeyAlgorithm::RS256)
+    .await
     .expect("Failed to add RSA384 key");
 
   validate_jwt_with_keystores("id_token_rsa256.txt", &ks_good, &ks_bad).await;
@@ -101,8 +104,9 @@ async fn rsa256_valid_jwt() {
 async fn rsa256_invalid_claims_expired_jwt() {
   let ks = KeyStore::new().await.unwrap();
   ks.add_rsa_pem_key(&load_asset("rsa.pub.key"), Some("key-1"), KeyAlgorithm::RS256)
+    .await
     .expect("Failed to add RSA key");
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* verify expired token, must fail */
   let jwt = load_asset("id_token_rsa256_expired.txt");
@@ -131,8 +135,9 @@ async fn rsa256_invalid_claims_expired_jwt() {
 async fn rsa256_valid_claims_expired_jwt() {
   let ks = KeyStore::new().await.unwrap();
   ks.add_rsa_pem_key(&load_asset("rsa.pub.key"), Some("key-1"), KeyAlgorithm::RS256)
+    .await
     .expect("Failed to add RSA key");
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* verify expired token, must fail */
   let jwt = load_asset("id_token_rsa256_expired.txt");
@@ -146,11 +151,13 @@ async fn rsa384_valid_jwt() {
   let ks_good = KeyStore::new().await.unwrap();
   ks_good
     .add_rsa_pem_key(&load_asset("rsa.pub.key"), Some("key-1"), KeyAlgorithm::RS384)
+    .await
     .expect("Failed to add RSA384 key");
 
   let ks_bad = KeyStore::new().await.unwrap();
   ks_bad
     .add_rsa_pem_key(&load_asset("rsa.wrong.pub.key"), Some("key-1"), KeyAlgorithm::RS384)
+    .await
     .expect("Failed to add RSA384 key");
 
   validate_jwt_with_keystores("id_token_rsa384.txt", &ks_good, &ks_bad).await;
@@ -162,8 +169,9 @@ async fn rsa384_valid_jwt() {
 async fn rsa512_valid_jwt() {
   let ks = KeyStore::new().await.unwrap();
   ks.add_rsa_pem_key(&load_asset("rsa.pub.key"), Some("key-1"), KeyAlgorithm::RS512)
+    .await
     .expect("Failed to add RSA key");
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* verify valid token */
   let jwt = load_asset("id_token_rsa512.txt");
@@ -179,6 +187,7 @@ async fn es256_valid_jwt() {
   let ks_good = KeyStore::new().await.unwrap();
   ks_good
     .add_ec_pem_key(&load_asset("ec256.pub.key"), Some("key-1"), EcCurve::P256, KeyAlgorithm::ES256)
+    .await
     .expect("Failed to add ec256 key");
 
   let ks_bad = KeyStore::new().await.unwrap();
@@ -189,6 +198,7 @@ async fn es256_valid_jwt() {
       EcCurve::P256,
       KeyAlgorithm::ES256,
     )
+    .await
     .expect("Failed to add EC256 key");
 
   validate_jwt_with_keystores("id_token_es256.txt", &ks_good, &ks_bad).await;
@@ -206,8 +216,9 @@ async fn es256_expired_jwt() {
     EcCurve::P256,
     KeyAlgorithm::ES256,
   )
+  .await
   .expect("Failed to add EC key");
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* verify valid token */
   let jwt = load_asset("id_token_es256_expired.txt");
@@ -226,8 +237,9 @@ async fn es256_signature_invalid_jwt() {
     EcCurve::P256,
     KeyAlgorithm::ES256,
   )
+  .await
   .expect("Failed to add EC key");
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* verify valid token */
   let jwt = load_asset("id_token_es256_signature_invalid.txt");
@@ -241,6 +253,7 @@ async fn es384_valid_jwt() {
   let ks_good = KeyStore::new().await.unwrap();
   ks_good
     .add_ec_pem_key(&load_asset("ec384.pub.key"), Some("key-1"), EcCurve::P384, KeyAlgorithm::ES384)
+    .await
     .expect("Failed to add ec384 key");
 
   let ks_bad = KeyStore::new().await.unwrap();
@@ -251,6 +264,7 @@ async fn es384_valid_jwt() {
       EcCurve::P384,
       KeyAlgorithm::ES384,
     )
+    .await
     .expect("Failed to add EC384 key");
 
   validate_jwt_with_keystores("id_token_es384.txt", &ks_good, &ks_bad).await;
@@ -268,6 +282,7 @@ async fn ed25519_valid_jwt() {
       EcCurve::Ed25519,
       KeyAlgorithm::EdDSA,
     )
+    .await
     .expect("Failed to add Ed25519 key");
 
   let ks_bad = KeyStore::new().await.unwrap();
@@ -278,6 +293,7 @@ async fn ed25519_valid_jwt() {
       EcCurve::Ed25519,
       KeyAlgorithm::EdDSA,
     )
+    .await
     .expect("Failed to add Ed25519 key");
 
   validate_jwt_with_keystores("id_token_ed25519.txt", &ks_good, &ks_bad).await;
@@ -289,15 +305,15 @@ async fn ed25519_valid_jwt() {
 async fn load_ed25519_jwk() {
   let mut ks = KeyStore::new().await.unwrap();
   let jwk_json = load_asset("ed25519.pub.jwk.json");
-  ks.add_key(&jwk_json).unwrap();
+  ks.add_key(&jwk_json).await.unwrap();
 
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* get the key by name */
-  ks.key_by_id(Some("key-1")).unwrap();
+  ks.key_by_id(Some("key-1")).await.unwrap();
 
   /* get key with wrong name, must fail */
-  assert!(ks.key_by_id(Some("No-key-with-that-name")).is_err());
+  assert!(ks.key_by_id(Some("No-key-with-that-name")).await.is_err());
 }
 
 ///
@@ -306,13 +322,13 @@ async fn load_ed25519_jwk() {
 async fn load_ec_jwk() {
   let mut ks = KeyStore::new().await.unwrap();
   let jwk_json = load_asset("ec256.pub.jwk.json");
-  ks.add_key(&jwk_json).unwrap();
+  ks.add_key(&jwk_json).await.unwrap();
 
-  assert_eq!(ks.keys_len(), 1);
+  assert_eq!(ks.keys_len().await, 1);
 
   /* get the key by name */
-  ks.key_by_id(Some("ec2561")).unwrap();
+  ks.key_by_id(Some("ec2561")).await.unwrap();
 
   /* get key with wrong name, must fail */
-  assert!(ks.key_by_id(Some("No-key-with-that-name")).is_err());
+  assert!(ks.key_by_id(Some("No-key-with-that-name")).await.is_err());
 }


### PR DESCRIPTION
changed the keyset (in the KeyStore struct) to use tokio::sync::RwLock (instead of std::sync::RwLock). The tokio::sync::RwLock "is fair (or write-preferring), in order to ensure that readers cannot starve writers". This also removes the possibility of deadlocks due to panics (albeit unlikely regardless). As a result, several functions in keystore.rs have now become async.